### PR TITLE
Conditionally show in-development content

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,0 +1,2 @@
+MEETUPS=true
+DRIBBBLE=true

--- a/lib/community.ex
+++ b/lib/community.ex
@@ -6,6 +6,10 @@ defmodule Community do
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
+    unless Mix.env == "prod" do
+      Envy.auto_load
+    end
+
     children = [
       # Start the endpoint when the application starts
       supervisor(Community.Endpoint, []),

--- a/mix.exs
+++ b/mix.exs
@@ -41,6 +41,7 @@ defmodule Community.Mixfile do
   defp deps do
     [
       {:cowboy, "~> 1.0"},
+      {:envy, "~> 0.0.2"},
       {:ex_machina, "~> 0.6.1"},
       {:ex_spec, "~> 1.0.0", only: :test},
       {:gettext, "~> 0.9"},

--- a/mix.lock
+++ b/mix.lock
@@ -5,6 +5,7 @@
   "db_connection": {:hex, :db_connection, "0.2.4"},
   "decimal": {:hex, :decimal, "1.1.1"},
   "ecto": {:hex, :ecto, "2.0.0-beta.2"},
+  "envy": {:hex, :envy, "0.0.2"},
   "ex_machina": {:hex, :ex_machina, "0.6.1"},
   "ex_spec": {:hex, :ex_spec, "1.0.0"},
   "fs": {:hex, :fs, "0.9.2"},

--- a/web/templates/home_page/show.html.eex
+++ b/web/templates/home_page/show.html.eex
@@ -1,3 +1,9 @@
 <%= render "recent_jobs.html", jobs: @jobs, conn: @conn %>
-<%= render "recent_dribbbles.html" %>
-<%= render "recent_meetups.html" %>
+
+<%= if System.get_env("DRIBBBLE") == "true" do %>
+  <%= render "recent_dribbbles.html" %>
+<% end %>
+
+<%= if System.get_env("MEETUPS") == "true" do %>
+  <%= render "recent_meetups.html" %>
+<% end %>


### PR DESCRIPTION
We're going to release a first version without Dribbble shots or
Meetups, and add them in future development. These lets us hide the
existing design work in the meantime.
