### PR TITLE
Add tokens to jobs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -42,6 +42,7 @@ defmodule Community.Mixfile do
     [
       {:cowboy, "~> 1.0"},
       {:ex_machina, "~> 0.6.1"},
+      {:ex_spec, "~> 1.0.0", only: :test},
       {:gettext, "~> 0.9"},
       {:hound, "~> 0.8"},
       {:phoenix, "~> 1.1.4"},

--- a/mix.lock
+++ b/mix.lock
@@ -6,6 +6,7 @@
   "decimal": {:hex, :decimal, "1.1.1"},
   "ecto": {:hex, :ecto, "2.0.0-beta.2"},
   "ex_machina": {:hex, :ex_machina, "0.6.1"},
+  "ex_spec": {:hex, :ex_spec, "1.0.0"},
   "fs": {:hex, :fs, "0.9.2"},
   "gettext": {:hex, :gettext, "0.9.0"},
   "hackney": {:hex, :hackney, "1.4.8"},

--- a/priv/repo/migrations/20160422173353_add_token_to_job.exs
+++ b/priv/repo/migrations/20160422173353_add_token_to_job.exs
@@ -1,0 +1,11 @@
+defmodule Community.Repo.Migrations.AddTokenToJob do
+  use Ecto.Migration
+
+  def change do
+    execute "TRUNCATE TABLE jobs;"
+
+    alter table(:jobs) do
+      add :token, :uuid, null: false
+    end
+  end
+end

--- a/test/controllers/job_controller_test.exs
+++ b/test/controllers/job_controller_test.exs
@@ -67,5 +67,15 @@ defmodule Community.JobControllerTest do
         assert redirected_to(conn, 302) == "/"
       end
     end
+
+    context "when the job is not approved but the correct token is provided" do
+      it "renders the show" do
+        job = create(:job, approved: false)
+
+        conn = get conn, "/jobs/#{job.id}?token=#{job.token}"
+
+        assert html_response(conn, 200) =~ "This job is awaiting approval"
+      end
+    end
   end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -18,6 +18,7 @@ defmodule Community.ConnCase do
   using do
     quote do
       # Import conveniences for testing with connections
+      use ExSpec, async: true
       use Phoenix.ConnTest
 
       alias Community.Repo

--- a/web/controllers/job_controller.ex
+++ b/web/controllers/job_controller.ex
@@ -9,17 +9,28 @@ defmodule Community.JobController do
     |> render("index.html")
   end
 
+  def show(conn, %{"id" => id, "token" => token}) do
+    job = Repo.get_by(Job, id: id, token: token)
+    conn
+    |> show_job(job)
+  end
+
   def show(conn, %{"id" => id}) do
-    case Repo.get_by(Job, id: id, approved: true) do
-      nil ->
-        conn
-        |> put_flash(:error, "There is no approved job with that id")
-        |> redirect(to: root_path(conn, :show))
-      job ->
-        conn
-        |> assign(:job, job)
-        |> render(:show)
-    end
+    job = Repo.get_by(Job, id: id, approved: true)
+    conn
+    |> show_job(job)
+  end
+
+  defp show_job(conn, nil) do
+    conn
+    |> put_flash(:error, gettext("There is no job with that id"))
+    |> redirect(to: root_path(conn, :show))
+  end
+
+  defp show_job(conn, job) do
+    conn
+    |> assign(:job, job)
+    |> render(:show)
   end
 
   def new(conn, _params) do

--- a/web/models/job.ex
+++ b/web/models/job.ex
@@ -11,6 +11,7 @@ defmodule Community.Job do
     field :instructions, :string
     field :approved, :boolean, default: false
     field :preview, :boolean, default: false
+    field :token, Ecto.UUID, default: Ecto.UUID.generate
 
     timestamps
   end

--- a/web/templates/job/show.html.eex
+++ b/web/templates/job/show.html.eex
@@ -1,3 +1,7 @@
+<%= if !@job.approved do %>
+  <p>This job is awaiting approval</p>
+<% end %>
+
 <h3 class="slat-title"><%= @job.title %></h3>
 <h4 class="slat-subtitle"><%= @job.company %></h4>
 <p class="slat-meta"><%= @job.city %></p>


### PR DESCRIPTION
- Create a UUID token on create
- If the job page is visited with the token, show it
- Add a note about the fact that the job is not approved
