### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,6 +1,3 @@
 ADMIN_KEY=password
 ADMIN_EMAILS="admin@example.com,admin@raleighdesign.io"
-DRIBBBLE=true
 MANDRILL_API_KEY=12345
-MEETUPS=true
-NAVIGATION=true

--- a/test/acceptance/member_test.exs
+++ b/test/acceptance/member_test.exs
@@ -16,7 +16,7 @@ defmodule Community.Acceptance.MemberTest do
     check_label("member_available_for_hire")
 
     click_role "member-save"
-    assert String.contains?(visible_page_text, "Thank you for signing up!")
+    assert String.contains?(visible_page_text, "Thanks for signing up!")
 
     last_member = Repo.one(Member)
     assert last_member.name == "Scott Summers"

--- a/test/controllers/member_contact_controller_test.exs
+++ b/test/controllers/member_contact_controller_test.exs
@@ -5,6 +5,6 @@ defmodule Community.MemberContactControllerTest do
     member = create(:member, available_for_hire: true, approved: true)
     conn = post conn, "/members/#{member.id}/contact", contact_form: %{}
 
-    assert get_flash(conn, :error) == "You must fill out all the fields"
+    assert get_flash(conn, :error) == "Your email couldn't be sent"
   end
 end

--- a/test/controllers/member_controller_test.exs
+++ b/test/controllers/member_controller_test.exs
@@ -5,7 +5,7 @@ defmodule Community.MemberControllerTest do
   test "POST /members with invalid params", %{conn: conn} do
     conn = post conn, "/members", member: %{}
 
-    assert get_flash(conn, :error) == "You must fill out all the fields"
+    assert get_flash(conn, :error) == "Your profile couldn't be saved"
     assert Repo.one(Member) == nil
   end
 

--- a/web/controllers/member_contact_controller.ex
+++ b/web/controllers/member_contact_controller.ex
@@ -24,7 +24,7 @@ defmodule Community.MemberContactController do
       |> redirect(to: "/")
     else
       conn
-      |> put_flash(:error, "You must fill out all the fields")
+      |> put_flash(:error, "Your email couldn't be sent")
       |> assign(:changeset, changeset)
       |> assign(:member, member)
       |> render(:new)

--- a/web/controllers/member_controller.ex
+++ b/web/controllers/member_controller.ex
@@ -25,11 +25,12 @@ defmodule Community.MemberController do
       {:ok, member} ->
         send_emails(member)
         conn
-        |> put_flash(:info, "Thank you for signing up!")
+        |> put_flash(:info, "Thanks for signing up! An admin will approve your
+        account shortly. We've sent you an email with details.")
         |> redirect(to: member_path(conn, :index))
       {:error, changeset} ->
         conn
-        |> put_flash(:error, "You must fill out all the fields")
+        |> put_flash(:error, "Your profile couldn't be saved")
         |> render("new.html", changeset: changeset)
     end
   end

--- a/web/static/css/_delete-link.scss
+++ b/web/static/css/_delete-link.scss
@@ -1,0 +1,9 @@
+.delete-link {
+  float: right;
+  margin-bottom: $small-spacing;
+
+  &:hover,
+  &:focus {
+    color: $red;
+  }
+}

--- a/web/static/css/_outer-wrapper.scss
+++ b/web/static/css/_outer-wrapper.scss
@@ -1,0 +1,3 @@
+.outer-wrapper {
+  position: relative;
+}

--- a/web/static/css/_site-header.scss
+++ b/web/static/css/_site-header.scss
@@ -1,10 +1,14 @@
-.site-header-title {
-  @include margin($large-spacing null $base-spacing);
-  text-align: center;
+.site-header {
+  padding-top: $large-spacing;
 
   @include media($medium-screen-up) {
-    @include margin($x-large-spacing null null);
+    padding-top: $x-large-spacing;
   }
+}
+
+.site-header-title {
+  margin-bottom: $base-spacing;
+  text-align: center;
 
   a {
     @include hide-text;

--- a/web/static/css/app.scss
+++ b/web/static/css/app.scss
@@ -12,6 +12,7 @@
 @import "appended-link";
 @import "bulleted-list";
 @import "container";
+@import "delete-link";
 @import "dribbbles";
 @import "flashes";
 @import "gravatar-group";
@@ -20,6 +21,7 @@
 @import "longform-field";
 @import "meetups";
 @import "notation";
+@import "outer-wrapper";
 @import "page-action";
 @import "page-description";
 @import "page-title";

--- a/web/static/css/base/_variables.scss
+++ b/web/static/css/base/_variables.scss
@@ -56,7 +56,7 @@ $alert-color: shade($alert-background-color, 60%);
 
 $error-background-color: $red;
 $error-border-color: shade($error-background-color, 10%);
-$error-color: shade($error-background-color, 60%);
+$error-color: $white;
 
 // Box shadows:
 $base-box-shadow: 0 2px 4px rgba($base-font-color, 0.07);

--- a/web/templates/email/admin_member_added.text.eex
+++ b/web/templates/email/admin_member_added.text.eex
@@ -1,3 +1,6 @@
 New member signup!
 
 <%= @member.name %>
+
+You can approve it at the link below.
+<%= admin_member_url(Community.Endpoint, :edit, @member) %>

--- a/web/templates/email/contact_form.text.eex
+++ b/web/templates/email/contact_form.text.eex
@@ -5,5 +5,6 @@ Sent from: <%= @from %>
 Message:
 <%= @body %>
 
-Right now, your email address has not been exposed to the sender.
-If you reply to this email, your email addresss will be revealed to them.
+---
+Your email address has not been exposed to the sender.
+You can reply directly to this email, which will reveal your email address to them.

--- a/web/templates/email/job_posted.text.eex
+++ b/web/templates/email/job_posted.text.eex
@@ -1,7 +1,6 @@
-You created a job! It's hidden for now, but will go live once an admin approves
-it.
+You posted a job! It's hidden for now, but will go live once an admin approves it.
 
-<%= @job.title %>
+Title: <%= @job.title %>
 
 You can edit or delete your job at any time using the link below.
 

--- a/web/templates/email/member_added.text.eex
+++ b/web/templates/email/member_added.text.eex
@@ -1,5 +1,4 @@
-Thanks for signing up! It's hidden for now, but will go live once an admin approves
-it.
+Thanks for signing up! Your profile is hidden for now, but will go live once an admin approves it.
 
 You can edit or delete your profile at any time using the link below.
 

--- a/web/templates/job/index.html.eex
+++ b/web/templates/job/index.html.eex
@@ -1,7 +1,7 @@
 <p class="page-description">
   A resource for designers in Raleigh to find prospective
   career opportunities. Follow along on twitter,
-  <a href="http://twitter.com/raleighdesign">@raleighdesign</a>.
+  <a href="http://twitter.com/raleighdesignio">@raleighdesignio</a>.
 </p>
 
 <%= render "job_list.html", jobs: @jobs, conn: @conn %>

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -13,20 +13,20 @@
 
   <body>
     <%= render Community.SharedView, "flashes.html", conn: @conn %>
-    <div class="container">
-      <header class="site-header">
-        <h1 class="site-header-title">
-          <a href="/">Raleigh Design</a>
-        </h1>
-        <%= if System.get_env("NAVIGATION") == "true" do %>
+    <div class="outer-wrapper">
+      <div class="container">
+        <header class="site-header">
+          <h1 class="site-header-title">
+            <a href="/">Raleigh Design</a>
+          </h1>
           <nav role="navigation" class="site-navigation">
             <%= render Community.SharedView, "_navigation.html", conn: @conn %>
           </nav>
-        <% end %>
-      </header>
+        </header>
 
-      <%= render @view_module, @view_template, assigns %>
-      <%= render "_footer.html" %>
+        <%= render @view_module, @view_template, assigns %>
+        <%= render "_footer.html" %>
+      </div>
     </div>
 
     <script src="<%= static_path(@conn, "/js/app.js") %>"></script>

--- a/web/templates/member/edit.html.eex
+++ b/web/templates/member/edit.html.eex
@@ -4,8 +4,10 @@
     method: :delete,
     data: [
       confirm: "Are you sure you want to remove your profile?",
-    ]
+    ],
+    class: "delete-link"
 ) %>
+
 <%= render(
     "form.html",
     changeset: @changeset,

--- a/web/views/member_view.ex
+++ b/web/views/member_view.ex
@@ -1,9 +1,10 @@
 defmodule Community.MemberView do
   use Community.Web, :view
   @gravatar_host "https://secure.gravatar.com/avatar/"
+  @gravatar_size_query_param "?s=96"
 
   def gravatar(email) do
-    @gravatar_host <> hash_email(email)
+    @gravatar_host <> hash_email(email) <> @gravatar_size_query_param
   end
 
   defp hash_email(email) do


### PR DESCRIPTION
- Make the success flash more explicit
- Fix the text color for error messaging
- Pull a larger image from gravatar, so it's not stretched
- Clarify the reply-to for contact messages
- Position the delete link
- Don't wrap the text in emails. It forced a line break in the
  sent email
- Add an approval link to the admin member added emails
- Prevent the flash from covering up page actions
- Real twitter URL
- More generic flashes. The form errors cover specificity.
