### PR TITLE
Upgrade to CircleCI 2.0

### DIFF
--- a/bin/ci_test
+++ b/bin/ci_test
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-source ~/.asdf/asdf.sh
-export MIX_ENV="test"
-
-bin/test_suite

--- a/bin/setup
+++ b/bin/setup
@@ -3,15 +3,45 @@
 # Exit if any subcommand fails
 set -e
 
-cp .sample.env .env
+# set up environment variables if not set up yet
+if [ ! -f .env ]; then
+  echo "Copying .env file"
+  cp .sample.env .env
+fi
 
-# Set up phoenix
+# check if phantomjs is installed
+if ! command -v phantomjs >/dev/null; then
+  echo "You must install PhantomJS 2.x before continuing."
+  exit 1
+else
+  phantomjs_version=$(phantomjs -v)
+  major_version="${phantomjs_version%.*.*}"
+
+  if [ $major_version -lt 2 ]; then
+    echo "Please update your PhantomJS to 2.x before continuing."
+    exit 1
+  fi
+fi
+
+if [ -z "$CI" ]; then
+  echo "Removing previous build artifacts"
+  rm -rf node_modules
+  rm -rf deps _build
+  asdf install
+fi
+
+echo "Installing dependencies and compiling"
 mix local.hex --force
 mix local.rebar --force
 mix deps.get
 mix compile
 
-# Set up database
-mix development_seeds
+echo "Setting up the database"
+mix ecto.reset
+MIX_ENV="test" mix ecto.reset
+if [ -z "$CI" ]; then
+  mix development_seeds
+fi
 
+echo "Installing npm dependencies"
 npm install --progress=false

--- a/bin/test_suite
+++ b/bin/test_suite
@@ -1,5 +1,6 @@
 #!/bin/bash
 node_modules/.bin/brunch build
+mix compile --force --warnings-as-errors
 phantomjs --wd > /dev/null &
 phantom_pid=$!
 mix test

--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,6 @@ jobs:
       - restore_cache:
           keys:
           - dependency-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-          - dependency-cache-{{ .Branch }}
           - dependency-cache
       - restore_cache:
           keys:
@@ -33,9 +32,6 @@ jobs:
       - run: bin/test_suite
       - save_cache:
           key: dependency-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-          paths: "deps"
-      - save_cache:
-          key: dependency-cache-{{ .Branch }}
           paths: "deps"
       - save_cache:
           key: dependency-cache

--- a/circle.yml
+++ b/circle.yml
@@ -1,21 +1,56 @@
-machine:
-  pre:
-    - nvm install 5.6.0
-  node:
-    version: 5.6.0
-dependencies:
-  override:
-    - sudo bin/install_phantom
-    - bin/ci_setup
-    - rm -rf node_modules
-    - npm install --progress=false
-  cache_directories:
-    - ~/dependencies
-    - ~/.mix
-    - ~/.asdf
-    - ~/.node_modules
-    - _build
-    - deps
-test:
-  override:
-    - bin/ci_test
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/elixir:1.3.1-browsers
+        environment:
+          PHANTOMJS_VERSION: 2.1.1
+          CI: true
+    working_directory: /home/circleci/community
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - build-cache-{{ .Branch }}
+          - build-cache
+      - restore_cache:
+          keys:
+          - dependency-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+          - dependency-cache-{{ .Branch }}
+          - dependency-cache
+      - restore_cache:
+          keys:
+          - npm-cache-{{ .Branch }}-{{ checksum "package-lock.json" }}
+          - npm-cache-{{ .Branch }}
+          - npm-cache
+      - run:
+          name: Install NPM
+          command: |
+            curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash -
+            sudo apt-get install -y nodejs
+      - run: bin/setup
+      - run: bin/test_suite
+      - save_cache:
+          key: dependency-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+          paths: "deps"
+      - save_cache:
+          key: dependency-cache-{{ .Branch }}
+          paths: "deps"
+      - save_cache:
+          key: dependency-cache
+          paths: "deps"
+      - save_cache:
+          key: build-cache-{{ .Branch }}
+          paths: "_build"
+      - save_cache:
+          key: build-cache
+          paths: "_build"
+      - save_cache:
+          key: npm-cache-{{ .Branch }}-{{ checksum "package-lock.json" }}
+          paths: "node_modules"
+      - save_cache:
+          key: npm-cache-{{ .Branch }}
+          paths: "node_modules"
+      - save_cache:
+          key: npm-cache
+          paths: "node_modules"

--- a/circle.yml
+++ b/circle.yml
@@ -22,10 +22,6 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - build-cache-{{ .Branch }}
-          - build-cache
-      - restore_cache:
-          keys:
           - dependency-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
           - dependency-cache-{{ .Branch }}
           - dependency-cache
@@ -44,12 +40,6 @@ jobs:
       - save_cache:
           key: dependency-cache
           paths: "deps"
-      - save_cache:
-          key: build-cache-{{ .Branch }}
-          paths: "_build"
-      - save_cache:
-          key: build-cache
-          paths: "_build"
       - save_cache:
           key: npm-cache-{{ .Branch }}
           paths: "node_modules"

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/elixir:1.3.1-browsers
+      - image: circleci/elixir:1.5.1-browsers
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -14,6 +14,11 @@ jobs:
           POSTGRES_PASSWORD: postgres
     working_directory: /home/circleci/community
     steps:
+      - run:
+          name: Install NPM
+          command: |
+            curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash -
+            sudo apt-get install -y nodejs
       - checkout
       - restore_cache:
           keys:
@@ -26,14 +31,8 @@ jobs:
           - dependency-cache
       - restore_cache:
           keys:
-          - npm-cache-{{ .Branch }}-{{ checksum "package-lock.json" }}
           - npm-cache-{{ .Branch }}
           - npm-cache
-      - run:
-          name: Install NPM
-          command: |
-            curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash -
-            sudo apt-get install -y nodejs
       - run: bin/setup
       - run: bin/test_suite
       - save_cache:
@@ -51,9 +50,6 @@ jobs:
       - save_cache:
           key: build-cache
           paths: "_build"
-      - save_cache:
-          key: npm-cache-{{ .Branch }}-{{ checksum "package-lock.json" }}
-          paths: "node_modules"
       - save_cache:
           key: npm-cache-{{ .Branch }}
           paths: "node_modules"

--- a/circle.yml
+++ b/circle.yml
@@ -4,8 +4,14 @@ jobs:
     docker:
       - image: circleci/elixir:1.3.1-browsers
         environment:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
           PHANTOMJS_VERSION: 2.1.1
           CI: true
+      - image: postgres:9.6.2
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
     working_directory: /home/circleci/community
     steps:
       - checkout

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -35,6 +35,7 @@ config :phoenix, :stacktrace_depth, 20
 # Configure your database
 config :community, Community.Repo,
   adapter: Ecto.Adapters.Postgres,
+  username: System.get_env("POSTGRES_USER") || "postgres",
   database: "community_dev",
   hostname: "localhost",
   pool_size: 10

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -11,7 +11,7 @@ config :community, Community.Endpoint,
   debug_errors: true,
   code_reloader: true,
   check_origin: false,
-  watchers: [node: ["node_modules/brunch/bin/brunch", "watch", "--stdin"]]
+  watchers: [node: ["node_modules/brunch/bin/brunch", "watch", "--stdin", cd: Path.expand("../", __DIR__)]]
 
 # Watch static and templates for browser reloading.
 config :community, Community.Endpoint,


### PR DESCRIPTION
Won't pass until #85 is merged and this is rebased.

- Upgrade to CircleCI 2.0 infrastructure
- Cache dependency builds based on checksum of `mix.lock`
- Cache npm node_modules based on branch. This will work better once updated to npm@5 that uses `package-lock.json` so we can bust the cache based on the checksum of that file.