### PR TITLE
Add placeholder for meetup posts

### DIFF
--- a/web/static/css/_meetups.scss
+++ b/web/static/css/_meetups.scss
@@ -32,3 +32,136 @@
   font-weight: 400;
   margin-bottom: $x-small-spacing;
 }
+
+@-webkit-keyframes placeHolderShimmer {
+  0% {
+    background-position: -468px 0
+  }
+  100% {
+    background-position: 468px 0
+  }
+}
+
+@keyframes placeHolderShimmer {
+  0% {
+    background-position: -468px 0
+  }
+  100% {
+    background-position: 468px 0
+  }
+}
+
+.meetup-wrapper {
+  background-color: #e9eaed;
+  color: #141823;
+  padding: 10px;
+}
+
+.meetup-item {
+  background: #fff;
+  border: 1px solid;
+  border-color: #e5e6e9 #dfe0e4 #d0d1d5;
+  border-radius: 3px;
+  padding: 12px;
+  margin: 0 auto;
+  max-width: 672px;
+  min-height: 180px;
+}
+
+.animated-background {
+  -webkit-animation-duration: 1s;
+  animation-duration: 1s;
+  -webkit-animation-fill-mode: forwards;
+  animation-fill-mode: forwards;
+  -webkit-animation-iteration-count: infinite;
+  animation-iteration-count: infinite;
+  -webkit-animation-name: placeHolderShimmer;
+  animation-name: placeHolderShimmer;
+  -webkit-animation-timing-function: linear;
+  animation-timing-function: linear;
+  background: #f6f7f8;
+  background: #eeeeee;
+  background:
+  -webkit-gradient(linear, left top, right top, color-stop(8%, #eeeeee), color-stop(18%, #dddddd), color-stop(33%, #eeeeee));
+  background: -webkit-linear-gradient(left, #eeeeee 8%, #dddddd 18%, #eeeeee 33%);
+  background: linear-gradient(to right, #eeeeee 8%, #dddddd 18%, #eeeeee 33%);
+  -webkit-background-size: 800px 104px;
+  background-size: 800px 104px;
+  height: 60px;
+  position: relative;
+}
+
+.background-masker {
+  background: #fff;
+  position: absolute;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+.outlined .background-masker {
+  border: 1px solid #ddd;
+}
+
+.outlined:hover .background-masker {
+  border: none;
+}
+
+.outlined:hover .background-masker:hover {
+  border: 1px solid #ccc;
+  z-index: 1;
+}
+
+.background-masker.header-top,
+.background-masker.header-bottom,
+.background-masker.subheader-bottom {
+  top: 0;
+  left: 40px;
+  right: 0;
+  height: 10px;
+}
+
+.background-masker.header-left,
+.background-masker.subheader-left,
+.background-masker.header-right,
+.background-masker.subheader-right {
+  top: 10px;
+  left: 40px;
+  height: 8px;
+  width: 10px;
+}
+
+.background-masker.header-bottom {
+  top: 18px;
+  height: 6px;
+
+}
+
+.background-masker.subheader-left,
+.background-masker.subheader-right {
+  top: 24px;
+  height: 6px;
+}
+
+.background-masker.header-right,
+.background-masker.subheader-right {
+  width: auto;
+  left: 300px;
+  right: 0;
+}
+
+.background-masker.subheader-right {
+  left: 230px;
+}
+
+.background-masker.subheader-bottom {
+  top: 30px;
+  height: 10px;
+}
+
+.background-masker.content-top {
+  top: 40px;
+  left: 0;
+  right: 0;
+  height: 20px;
+}

--- a/web/static/js/meetup.js
+++ b/web/static/js/meetup.js
@@ -34,6 +34,9 @@ $(function() {
     dataType: "jsonp",
   }).done(function(data) {
     $.each(data.data, function(index, meetup) {
+      $("#meetup-placeholder").fadeOut("medium", function() {
+        $("#meetups").fadeIn("medium");
+      })
       let groupName = meetup.group.name;
       if ($.inArray(groupName, groupNames) === -1) {
         groupNames.push(groupName);

--- a/web/templates/home_page/recent_meetups.html.eex
+++ b/web/templates/home_page/recent_meetups.html.eex
@@ -8,7 +8,36 @@
     </p>
   </div>
 
-  <ol class="section-content slats" data-role="meetup-list">
+  <div class="section-content slats" id="meetup-placeholder">
+    <div class="meetup-wrapper">
+      <div class="meetup-item">
+        <div class="animated-background">
+          <div class="background-masker header-top"></div>
+          <div class="background-masker header-left"></div>
+          <div class="background-masker header-right"></div>
+          <div class="background-masker header-bottom"></div>
+          <div class="background-masker subheader-left"></div>
+          <div class="background-masker subheader-right"></div>
+          <div class="background-masker subheader-bottom"></div>
+          <div class="background-masker content-top"></div>
+        </div>
+      </div>
+      <div class="meetup-item">
+        <div class="animated-background">
+          <div class="background-masker header-top"></div>
+          <div class="background-masker header-left"></div>
+          <div class="background-masker header-right"></div>
+          <div class="background-masker header-bottom"></div>
+          <div class="background-masker subheader-left"></div>
+          <div class="background-masker subheader-right"></div>
+          <div class="background-masker subheader-bottom"></div>
+          <div class="background-masker content-top"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <ol class="section-content slats" data-role="meetup-list" style="display: none;" id="meetups">
     <li class="meetup-slat" data-role="meetup">
       <time class="meetup-time" data-role="date-time">2/7/15, 6:30PM</time>
       <div class="meetup-hgroup">
@@ -19,5 +48,5 @@
         <span class="notation" data-role="members">97 Members Going</span>
       </div>
     </li>
-  </ol>
+    </ol>
 </section>


### PR DESCRIPTION
We should have a placeholder that fades out when the meetup posts are
loading, especially important for first loads.
![meetup-placeholder-demo](https://user-images.githubusercontent.com/643967/36950559-a04cab70-1fc5-11e8-9cbc-388e769742b3.gif)
