### PR TITLE
Add Node and NPM versions to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "deploy": "brunch build --production",
     "watch": "brunch watch --stdin"
   },
+  "engines": {
+    "node": "9.2.0",
+    "npm": "5.5.1"
+  },
   "dependencies": {
     "blueimp-md5": "^2.3.0",
     "bourbon": "5.0.0-beta.6",


### PR DESCRIPTION
When I tried to deploy to a scratch heroku dyno, it rejected the build because it required the NodeJS version in `package.json`. I'm not sure when or what changed behavior, but reading Heroku's documentation this seems clear that if they see a `package.json` in the root of the project, they use their [nodejs buildpack](https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version) which reads the versions from `package.json`.

This adds the NodeJS and NPM version that's in `.tool-versions` and `phoenix_static_buildpack.config` to `package.json`