### PR TITLE
Fail fast when running test suite

### DIFF
--- a/bin/test_suite
+++ b/bin/test_suite
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 if [ ! -z "$CI" ]; then
   . "$HOME/.asdf/asdf.sh"


### PR DESCRIPTION
**PROBLEM**
The test suite may pass on CI even though there were warnings during compile

**SOLUTION**
Set `test_suite` to fail fast if any command exits non-zero.